### PR TITLE
Remove dependency on deprecated mongo-livedata

### DIFF
--- a/package.js
+++ b/package.js
@@ -8,10 +8,10 @@ Package.describe({
 Package.on_use(function(api) {
   if (api.versionsFrom) {
     api.versionsFrom('METEOR@0.9.1');
-    api.use(['templating', 'mongo-livedata']);
+    api.use(['templating', 'mongo']);
   } else {
-    api.use(['templating', 'mongo-livedata']);
+    api.use(['templating', 'mongo']);
   }
-  
+
   api.add_files(['delete-button.html', 'delete-button.js'], 'client');
 });


### PR DESCRIPTION
As of meteor 0.9.1, `mongo-livedata` has been moved to `mongo`.

I suggest to reflect this change here. This does not change anything to `aldeed:delete-button`, as it stays compatible from `METEOR@0.9.1`.